### PR TITLE
Fix SF3 violation building

### DIFF
--- a/Form/Type/ResetPasswordType.php
+++ b/Form/Type/ResetPasswordType.php
@@ -7,7 +7,7 @@ use Beelab\UserBundle\User\UserInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints as Assert;
-use Symfony\Component\Validator\ExecutionContextInterface;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 /**
  * Form for reset password.
@@ -65,7 +65,7 @@ class ResetPasswordType extends AbstractType
     public function findUser($email, ExecutionContextInterface $context)
     {
         if (is_null($user = $this->userManager->loadUserByUsername($email))) {
-            $context->addViolationAt('email', 'Email not found.');
+            $context->buildViolation('Email not found.')->atPath('email')->addViolation();       
         }
         $this->user = $user;
     }


### PR DESCRIPTION
Hello, 

Since SF2.5 constraint validations have changed: [see custom constraint](http://symfony.com/doc/2.7/validation/custom_constraint.html#creating-the-validator-itself)

According to BeelabUserBundle composer.json, the bundle supports SF > 2.8.

SF3 have now broken compatibility on this method call. I updated the method call making the bundle compatible with BeelabUserBundle SF requirements (^2.8.3|^3.2)

cheers,
Tristan
